### PR TITLE
Fix the test link in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,4 +36,7 @@ Do not expect to fetch a large repository with it.
 It can be tried with the current documentation, by providing parameters in the current URL of the documentation.
 
 As an example the following URL will reload the current page with some repo parameters:\
-[https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main](https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main)
+
+<a href="https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main">
+   https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main
+</a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,4 +36,4 @@ Do not expect to fetch a large repository with it.
 It can be tried with the current documentation, by providing parameters in the current URL of the documentation.
 
 As an example the following URL will reload the current page with some repo parameters:\
-<https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main>
+[https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main](https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main)


### PR DESCRIPTION
The test link in documentation is not properly parsed by my_st parser, the `&` are replaced with `&amp;`, which seems to break the search params.