### PR TITLE
Install playwright browser to fix build test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
 
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "@jupyterlite/litegitpuller.*OK"
+        npx playwright install chromium
         python -m jupyterlab.browser_check
 
     - name: Package the extension


### PR DESCRIPTION
Playwright `v1.38.0` do not automatically install browser anymore (https://github.com/microsoft/playwright/releases/tag/v1.38.0)
This break the build test, because the `jupyterlab/check_browser` do not install it.

Waiting for this to be fixed and released in `jupyterlab/check_browser`, this PR install the browser in the build test.