### PR TITLE
Test if nbgitpuller extension is installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,13 +128,38 @@ jobs:
     - name: Execute integration tests
       working-directory: ui-tests
       run: |
-        jlpm playwright test
+        jlpm playwright test --project general
 
     - name: Upload Playwright Test report
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: litegitpuller-playwright-tests
+        path: |
+          ui-tests/test-results
+          ui-tests/playwright-report
+
+  nbgitpuller-test:
+    name: nbgitpuller tests
+    needs: integration-tests
+    runs-on: ubuntu-latest
+
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
+
+    steps:
+    - name: Install nbgitpuller
+      run: pip install nbgitpuller
+
+    - name: Execute test
+      working-directory: ui-tests
+      run: jlpm playwright test --project nbgitpuller
+
+    - name: Upload Test report
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: litegitpuller-nbgitpuller-tests
         path: |
           ui-tests/test-results
           ui-tests/playwright-report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     - name: Execute integration tests
       working-directory: ui-tests
       run: |
-        jlpm playwright test --project general
+        jlpm playwright test --project ${{ matrix.project }}
 
     - name: Upload Playwright Test report
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,9 @@ jobs:
     name: Integration tests
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [general, nbgitpuller]
 
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
@@ -101,6 +104,10 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: extension-artifacts
+
+    - name: Install nbgitpuller
+      if: ${{ matrix.project == 'nbgitpuller' }}
+      run: pip install nbgitpuller
 
     - name: Install the extension
       run: |
@@ -134,32 +141,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: litegitpuller-playwright-tests
-        path: |
-          ui-tests/test-results
-          ui-tests/playwright-report
-
-  nbgitpuller-test:
-    name: nbgitpuller tests
-    needs: integration-tests
-    runs-on: ubuntu-latest
-
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
-
-    steps:
-    - name: Install nbgitpuller
-      run: pip install nbgitpuller
-
-    - name: Execute test
-      working-directory: ui-tests
-      run: jlpm playwright test --project nbgitpuller
-
-    - name: Upload Test report
-      if: failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: litegitpuller-nbgitpuller-tests
+        name: litegitpuller-ui-tests_${{ matrix.project }}
         path: |
           ui-tests/test-results
           ui-tests/playwright-report

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
   ) => {
     if (await testNbGitPuller()) {
       console.log(
-        '@jupyterlite/litegitpuller is not activated to avoid conflict with nbgitpuller'
+        '@jupyterlite/litegitpuller is not activated, to avoid conflict with nbgitpuller'
       );
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,58 @@ import {
 } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
+import { ServerConnection } from '@jupyterlab/services';
 import { GitPuller, GithubPuller, GitlabPuller } from './gitpuller';
+
+/**
+ * Test if nbgitpuller extension is also installed by requesting its Rest API.
+ * This test avoid fetching the same repository two times.
+ */
+export async function testNbGitPuller(): Promise<boolean> {
+  // Make request to Jupyter API
+  const settings = ServerConnection.makeSettings();
+  const params = {
+    repo: 'https://github.com/jupyterlite/litegitpuller',
+    branch: 'main'
+  };
+  const searchParams = new URLSearchParams(params);
+  const requestUrl = `${settings.baseUrl}git-pull/api?${searchParams}`;
+  let response: Response;
+  try {
+    response = await ServerConnection.makeRequest(
+      requestUrl,
+      { method: 'GET' },
+      settings
+    );
+  } catch (error) {
+    return false;
+  }
+
+  if (!response.ok) {
+    return false;
+  }
+
+  return true;
+}
 
 const gitPullerExtension: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlite/litegitpuller:plugin',
   autoStart: true,
   requires: [IDefaultFileBrowser],
-  activate: (app: JupyterFrontEnd, defaultFileBrowser: IDefaultFileBrowser) => {
+  activate: async (
+    app: JupyterFrontEnd,
+    defaultFileBrowser: IDefaultFileBrowser
+  ) => {
+    if (await testNbGitPuller()) {
+      console.log(
+        '@jupyterlite/litegitpuller is not activated to avoid conflict with nbgitpuller'
+      );
+      return;
+    }
+
     console.log(
       'JupyterLab extension @jupyterlite/litegitpuller is activated!'
     );
-    if (!(app.name === 'JupyterLite')) {
-      return;
-    }
 
     const urlParams = new URLSearchParams(window.location.search);
     const repo = urlParams.get('repo');

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { PathExt } from '@jupyterlab/coreutils';
+import { PathExt, URLExt } from '@jupyterlab/coreutils';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 import { ServerConnection } from '@jupyterlab/services';
 import { GitPuller, GithubPuller, GitlabPuller } from './gitpuller';
@@ -14,12 +14,7 @@ import { GitPuller, GithubPuller, GitlabPuller } from './gitpuller';
 export async function testNbGitPuller(): Promise<boolean> {
   // Make request to Jupyter API
   const settings = ServerConnection.makeSettings();
-  const params = {
-    repo: 'https://github.com/jupyterlite/litegitpuller',
-    branch: 'main'
-  };
-  const searchParams = new URLSearchParams(params);
-  const requestUrl = `${settings.baseUrl}git-pull/api?${searchParams}`;
+  const requestUrl = URLExt.join(settings.baseUrl, 'git-pull', 'api');
   let response: Response;
   try {
     response = await ServerConnection.makeRequest(

--- a/ui-tests/nbgitpuller_test/test.spec.ts
+++ b/ui-tests/nbgitpuller_test/test.spec.ts
@@ -17,7 +17,9 @@ test('should emit an activation console message', async ({ page }) => {
 
   expect(
     logs.filter(
-      s => s === '@jupyterlite/litegitpuller is not activated, to avoid conflict with nbgitpuller'
+      s =>
+        s ===
+        '@jupyterlite/litegitpuller is not activated, to avoid conflict with nbgitpuller'
     )
   ).toHaveLength(1);
 });

--- a/ui-tests/nbgitpuller_test/test.spec.ts
+++ b/ui-tests/nbgitpuller_test/test.spec.ts
@@ -1,9 +1,13 @@
 import { expect, test } from '@jupyterlab/galata';
 
 /**
- * Don't load JupyterLab webpage before running the tests.
- * This is required to ensure we capture all log messages.
+ * ### NOTE:
+ * This test is supposed to run with nbgitpuller extension installed, to make
+ * sure that the litegitpuller extension is not activated in that case.
  */
+
+//Don't load JupyterLab webpage before running the tests.
+//This is required to ensure we capture all log messages.
 test.use({ autoGoto: false });
 
 test('should emit an activation console message', async ({ page }) => {

--- a/ui-tests/nbgitpuller_test/test.spec.ts
+++ b/ui-tests/nbgitpuller_test/test.spec.ts
@@ -10,7 +10,7 @@ import { expect, test } from '@jupyterlab/galata';
 //This is required to ensure we capture all log messages.
 test.use({ autoGoto: false });
 
-test('should emit an activation console message', async ({ page }) => {
+test('should emit a non activation console message', async ({ page }) => {
   const logs: string[] = [];
 
   page.on('console', message => {

--- a/ui-tests/nbgitpuller_test/test.spec.ts
+++ b/ui-tests/nbgitpuller_test/test.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@jupyterlab/galata';
+
+/**
+ * Don't load JupyterLab webpage before running the tests.
+ * This is required to ensure we capture all log messages.
+ */
+test.use({ autoGoto: false });
+
+test('should emit an activation console message', async ({ page }) => {
+  const logs: string[] = [];
+
+  page.on('console', message => {
+    logs.push(message.text());
+  });
+
+  await page.goto();
+
+  expect(
+    logs.filter(
+      s => s === '@jupyterlite/litegitpuller is not activated, to avoid conflict with nbgitpuller'
+    )
+  ).toHaveLength(1);
+});

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "start": "jupyter lab --config jupyter_server_test_config.py",
-    "test": "jlpm playwright test",
+    "test": "jlpm playwright test --project general",
+    "test:nbgitpuller": "jlpm playwright test --project nbgitpuller",
     "test:update": "jlpm playwright test --update-snapshots"
   },
   "devDependencies": {

--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -10,5 +10,15 @@ module.exports = {
     url: 'http://localhost:8888/lab',
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI
-  }
+  },
+  projects: [
+    {
+      name: 'general',
+      testMatch: 'tests/*.spec.ts'
+    },
+    {
+      name: 'nbgitpuller',
+      testMatch: 'nbgitpuller_test/*.spec.ts'
+    }
+  ]
 };


### PR DESCRIPTION
Fixes https://github.com/jupyterlite/litegitpuller/issues/5

This PR add a test on *nbgitpuller* extension, by making a request to one of its endpoint.

If *nbgitpuller* extension is enabled, *litegitpuller* is not activated, to avoid fetching two times the same repo.

cc @jtpio, who suggests this workaround