### PR TITLE
Preserve file extension for unique filenames

### DIFF
--- a/src/gitpuller.ts
+++ b/src/gitpuller.ts
@@ -138,7 +138,7 @@ export abstract class GitPuller {
       await this._contents
         .get(filename, { content: false })
         .then(() => {
-          filename = `${filename}_${inc}`;
+          filename = `${inc}_${filename}`;
           inc++;
         })
         .catch(e => {


### PR DESCRIPTION
When a file is uploaded and has a name clash, a unique filename must be chosen. The current method appends the increment after the pathname, which interferes with the file extension, e.g. `README.md` becomes `README.md_0`. (Since the contents API uses the extension to determine how to interpret the file, this causes plain text files to be displayed as base64 encoded). The new variant puts the disambiguator in front to preserve the extension.