### PR TITLE
Use filepath relative to repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A jupyterlite extension to automate cloning of a github repository.
 
 ## Docs
 
-See [https://litegitpuller.readthedocs.io/en/latest/index.html](https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main)
+See [https://litegitpuller.readthedocs.io/en/latest/index.html](https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=notebooks%2Fsimple.ipynb&branch=main)
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,14 +43,14 @@ Jupyterlite embedded in the page.
 
 - Fetching a Github repository:
 
-   <a href="https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main">
-      https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main
+   <a href="https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=notebooks%2Fsimple.ipynb&branch=main">
+      https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgithub.com%2Fbrichet%2Ftesting-repo&urlpath=notebooks%2Fsimple.ipynb&branch=main
    </a>
 
 - Fetching a Gitlab repository:
 
-  <a href="https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgitlab.com%2Fbrichet1%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&branch=main&
+  <a href="https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgitlab.com%2Fbrichet1%2Ftesting-repo&urlpath=notebooks%2Fsimple.ipynb&branch=main&
    provider=gitlab">
-  https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgitlab.com%2Fbrichet1%2Ftesting-repo&urlpath=tree%2Ftesting-repo%2Fnotebooks%2Fsimple.ipynb&
+  https://litegitpuller.readthedocs.io/en/latest/index.html?repo=https%3A%2F%2Fgitlab.com%2Fbrichet1%2Ftesting-repo&urlpath=notebooks%2Fsimple.ipynb&
   branch=main&provider=gitlab
   </a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
     const basePath = PathExt.basename(repo);
     const branch = urlParams.get('branch') || 'main';
     const provider = urlParams.get('provider') || 'github';
-    let filePath = urlParams.get('urlpath');
+    const filePath = urlParams.get('urlpath');
 
     const repoUrl = new URL(repo);
     if (provider === 'github') {
@@ -97,10 +97,8 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
 
     puller.clone(repoUrl.href, branch, basePath).then(async basePath => {
       if (filePath) {
-        // TODO: delete the following line as soon as a dedicated url generator is available.
-        filePath = PathExt.relative('tree/', filePath);
         app.commands.execute('filebrowser:open-path', {
-          path: filePath
+          path: PathExt.join(basePath, filePath)
         });
       }
     });


### PR DESCRIPTION
The docs mention that the `urlpath` parameter is relative to the repository root (see https://litegitpuller.readthedocs.io/en/latest/index.html#parameters), which is currently not the case.

This PR fixes the code to interpret the `urlpath` parameter relative to the repository root, which is a breaking change. This behaviour is useful when the repo is not uploaded to a statically known path, e.g. by (in the future) uploading it to the currently opened working directory.

While we theoretically could detect paths starting with `tree/` to get back the original behaviour, this would clash with folders named `tree` inside the repository. Opening a path outside the repo is still possible by giving an absolute path, e.g. `/README.md` (since absolute paths come out of a join unchanged and JupyterLab strips the leading slash).