### PR TITLE
Upload to current working directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,10 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
 
     let puller: GitPuller | null = null;
 
-    const basePath = PathExt.join(defaultFileBrowser.model.path, PathExt.basename(repo));
+    const basePath = PathExt.join(
+      defaultFileBrowser.model.path,
+      PathExt.basename(repo)
+    );
     const branch = urlParams.get('branch') || 'main';
     const provider = urlParams.get('provider') || 'github';
     let filePath = urlParams.get('urlpath');

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
 
     let puller: GitPuller | null = null;
 
-    const basePath = PathExt.basename(repo);
+    const basePath = PathExt.join(defaultFileBrowser.model.path, PathExt.basename(repo));
     const branch = urlParams.get('branch') || 'main';
     const provider = urlParams.get('provider') || 'github';
     let filePath = urlParams.get('urlpath');


### PR DESCRIPTION
Supersedes #23

Upload the repository to the current working directory instead of the root.

Since this extension is loaded at startup, it should not cause any change in behaviour. However, it enables additional usecases such as https://github.com/jupyterlite/jupyterlite/issues/1518