### PR TITLE
Upload to a user-provided `uploadpath`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,8 @@ Currently the allowed parameters are:
 - `repo`: (**required**) the github repository to fetch.
 - `branch`: the branch of the repository to fetch (default to _main_).
 - `urlpath`: the path to a notebook file to open (relative to the root of the repository).
-- `provider`: The provider of the API. Currently it supports _Github_ and _Gitlab_ API.
+- `provider`: the provider of the API. Currently it supports _Github_ and _Gitlab_ API.
+- `uploadpath`: the path to the directory in which the repository directory is created.
 
 ## Limitations
 

--- a/src/gitpuller.ts
+++ b/src/gitpuller.ts
@@ -26,7 +26,7 @@ export abstract class GitPuller {
     const basePathComponents = basePath.split('/');
     const basePathPrefixes = [];
     for (let i = 0; i < basePathComponents.length; i++) {
-      basePathPrefixes.push(basePathComponents.slice(0, i+1).join('/'));
+      basePathPrefixes.push(basePathComponents.slice(0, i + 1).join('/'));
     }
 
     // For a basePath 'a/b/c', create ['a', 'a/b', 'a/b/c']

--- a/src/gitpuller.ts
+++ b/src/gitpuller.ts
@@ -23,7 +23,14 @@ export abstract class GitPuller {
    * @returns the path of the created directory.
    */
   async clone(url: string, branch: string, basePath: string): Promise<string> {
-    await this.createTree([basePath]);
+    const basePathComponents = basePath.split('/');
+    const basePathPrefixes = [];
+    for (let i = 0; i < basePathComponents.length; i++) {
+      basePathPrefixes.push(basePathComponents.slice(0, i+1).join('/'));
+    }
+
+    // For a basePath 'a/b/c', create ['a', 'a/b', 'a/b/c']
+    await this.createTree(basePathPrefixes);
 
     const fileList = await this.getFileList(url, branch);
 

--- a/src/gitpuller.ts
+++ b/src/gitpuller.ts
@@ -103,10 +103,12 @@ export abstract class GitPuller {
         path: PathExt.dirname(directory)
       };
       // Create directory if it does not exist.
-      await this._contents.get(directory, { content: false }).catch(async () => {
-        const newDirectory = await this._contents.newUntitled(options);
-        await this._contents.rename(newDirectory.path, directory);
-      });
+      await this._contents
+        .get(directory, { content: false })
+        .catch(async () => {
+          const newDirectory = await this._contents.newUntitled(options);
+          await this._contents.rename(newDirectory.path, directory);
+        });
     }
   }
 

--- a/src/gitpuller.ts
+++ b/src/gitpuller.ts
@@ -103,10 +103,9 @@ export abstract class GitPuller {
         path: PathExt.dirname(directory)
       };
       // Create directory if it does not exist.
-      await this._contents.get(directory, { content: false }).catch(() => {
-        this._contents.newUntitled(options).then(async newDirectory => {
-          await this._contents.rename(newDirectory.path, directory);
-        });
+      await this._contents.get(directory, { content: false }).catch(async () => {
+        const newDirectory = await this._contents.newUntitled(options);
+        await this._contents.rename(newDirectory.path, directory);
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
       return;
     }
 
-    puller.clone(repoUrl.href, branch, basePath).then(async repoPath => {
+    puller.clone(repoUrl.href, branch, basePath).then(repoPath => {
       if (filePath) {
         app.commands.execute('filebrowser:open-path', {
           path: PathExt.join(repoPath, filePath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,10 +61,12 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
 
     let puller: GitPuller | null = null;
 
-    const basePath = PathExt.basename(repo);
     const branch = urlParams.get('branch') || 'main';
     const provider = urlParams.get('provider') || 'github';
     const filePath = urlParams.get('urlpath');
+    const uploadPath = urlParams.get('uploadpath') | '/';
+
+    const basePath = PathExt.join(uploadPath, PathExt.basename(repo));
 
     const repoUrl = new URL(repo);
     if (provider === 'github') {
@@ -95,10 +97,10 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
       return;
     }
 
-    puller.clone(repoUrl.href, branch, basePath).then(async basePath => {
+    puller.clone(repoUrl.href, branch, basePath).then(async repoPath => {
       if (filePath) {
         app.commands.execute('filebrowser:open-path', {
-          path: PathExt.join(basePath, filePath)
+          path: PathExt.join(repoPath, filePath)
         });
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ const gitPullerExtension: JupyterFrontEndPlugin<void> = {
     const branch = urlParams.get('branch') || 'main';
     const provider = urlParams.get('provider') || 'github';
     const filePath = urlParams.get('urlpath');
-    const uploadPath = urlParams.get('uploadpath') | '/';
+    const uploadPath = urlParams.get('uploadpath') || '/';
 
     const basePath = PathExt.join(uploadPath, PathExt.basename(repo));
 


### PR DESCRIPTION
Upload the repository to a user-provided `uploadpath`, which is given as an optional query parameter. The directory `PathExt.join(uploadPath, PathExt.basename(repo))` is created. By default, `uploadpath` is `'/'`, i.e. the repository is uploaded to `PathExt.basename(repo)` as before.

Supersedes #25.